### PR TITLE
feature/ eon:package:validate new flag to set only test class execution

### DIFF
--- a/messages/validate.json
+++ b/messages/validate.json
@@ -6,10 +6,16 @@
   "packageFlag": "Validate one selected package",
   "poolFlag": "Pool tag to fetch scratch orgs",
   "devAliasFlag": "Target dev hub alias",
-  "examples": ["sfdx eon:validate", "sfdx  eon:validate"],
+  "examples": [
+   "sfdx eon:validate -t origin/main",
+   "sfdx  eon:validate -t origin/main -p core",
+   "sfdx  eon:validate -t origin/main -p core -o",
+   "sfdx  eon:validate --target origin/main --package --onlytests"
+  ],
   "errorDeployment": "Process finsihed with Exit Code 1.",
   "errorFoundNoApex": "Query Apex from Org failed: %s",
   "errorApexQueueInsert": "Testclass cannot inserted to TestQueue.See error messages",
   "errorApexQueueSelect": "Select on Object ApexTestQueueItem not possible",
-  "errorCodeCoverage": "No Apex Test Coverage found"
+  "errorCodeCoverage": "No Apex Test Coverage found",
+  "testclassFlag": "Run validation without deployment only for testclass execution"
 }

--- a/messages/validate_source.json
+++ b/messages/validate_source.json
@@ -4,5 +4,10 @@
   "targetFlag": "Flag for target branch",
   "scriptFlag": "Flag to run pre/post deployment scripts",
   "packageFlag": "Validate one selected package",
-  "examples": ["sfdx eon:validate:source", "sfdx  eon:validate:source -p mypackage"]
+  "examples": [
+    "sfdx eon:validate:source",
+    "sfdx  eon:validate:source -p mypackage",
+    "sfdx  eon:validate:source -p mypackage -o",
+    "sfdx  eon:validate:source --package mypackage --onlytests"
+    ]
 }

--- a/src/commands/eon/package/validate.ts
+++ b/src/commands/eon/package/validate.ts
@@ -90,6 +90,11 @@ export default class Validate extends SfdxCommand {
       default: '',
       required: false,
     }),
+    onlytests: flags.boolean({
+      char: 'o',
+      description: messages.getMessage('testclassFlag'),
+      required: false,
+    }),
   };
 
   // Set this to true if your command requires a project workspace; 'requiresProject' is false by default
@@ -123,9 +128,13 @@ export default class Validate extends SfdxCommand {
       let packageCheck = false;
       if (this.flags.package) {
         if (pck.package === this.flags.package) {
+          if (!packageAliases[pck.package]) {
+            EONLogger.log(COLOR_WARNING(`👆 No validation for source packages: ${pck.package}`));
+            continue;
+          }
           packageMap.set(pck.package, pck);
           table.push([pck.package]);
-          continue;
+          break;
         }
       }
       packageCheck = changes.files.some((change) => {
@@ -212,7 +221,11 @@ Please put your changes in a (new) unlocked package or a (new) source package. T
       //Start deploy process
 
       //Deploy Unlocked Package
+      if(!this.flags.onlytests){
       await this.deployPackageWithDependency(key, value.path);
+      } else {
+        EONLogger.log(COLOR_WARNING(`👆 No deployment, only testclass execution`));
+      }
 
       //Run Tests
       await this.getApexClassesFromPaths(key, value.path);

--- a/src/commands/eon/package/validate/source.ts
+++ b/src/commands/eon/package/validate/source.ts
@@ -103,9 +103,13 @@ export default class Validate extends SfdxCommand {
       let packageCheck = false;
       if (this.flags.package) {
         if (pck.package === this.flags.package && this.flags.package.search('src') > -1) {
+          if (!packageAliases[pck.package]) {
+            EONLogger.log(COLOR_WARNING(`👆 No validation for unlocked packages: ${pck.package}`));
+            continue;
+          }
           packageMap.set(pck.package, pck);
           table.push([pck.package]);
-          continue;
+          break;
         }
       }
       packageCheck = changes.files.some((change) => {
@@ -158,6 +162,8 @@ export default class Validate extends SfdxCommand {
         if (!packageAliases[pck.package]) {
           packageMap.set(pck.package, pck);
           table.push([pck.package]);
+        } else {
+          EONLogger.log(COLOR_WARNING(`👆 No validation for unlocked packages: ${pck.package}`));
         }
       }
     }


### PR DESCRIPTION
HI @con242 This feature has a new flag in the unlocked package validation command to execute only testclasses. Without deployment step.