### PR TITLE
fix/eon:package:validate:source empty table for test class errors

### DIFF
--- a/src/commands/eon/package/validate/source.ts
+++ b/src/commands/eon/package/validate/source.ts
@@ -208,7 +208,7 @@ Please put your changes in a (new) unlocked package or a (new) source package. T
       wordWrap: true,
     });
     //print deployment errors
-    if (input.componentFailures) {
+    if ((Array.isArray(input.componentFailures) && input.componentFailures.length > 0) || (typeof input.componentFailures === 'object' && Object.keys(input.componentFailures).length > 0)) {
       let result: DeployError[] = [];
       if (Array.isArray(input.componentFailures)) {
         result = input.componentFailures.map((a) => {


### PR DESCRIPTION
Fixes the empty table issue for source packages when we have testclass errors