### PR TITLE
Feature/change deprecated sfdx apex command

### DIFF
--- a/src/commands/eon/package/devkit/apply.ts
+++ b/src/commands/eon/package/devkit/apply.ts
@@ -78,7 +78,7 @@ export default class Apply extends SfdxCommand {
           title: `Executing Apex: ${devkit.anonymous_apex}`,
           task: async () => {
             try {
-              await execa('sfdx', ['apex:execute', '-f ', script]);
+              await execa('sfdx', ['apex:run', '-f ', script]);
               EONLogger.log(COLOR_TRACE('Script executed'));
             } catch (error) {
               EONLogger.log(COLOR_NOTIFY('Executing Anonymous Apex finished with following message:'));

--- a/src/commands/eon/package/devkit/apply.ts
+++ b/src/commands/eon/package/devkit/apply.ts
@@ -64,7 +64,7 @@ export default class Apply extends SfdxCommand {
         task: async () => {
           const permissionsets: string = devkit.permissionsets.join(',');
           try {
-            await execa('sfdx', ['force:user:permset:assign', '--permsetname',  permissionsets, '--json']);
+            await execa('sfdx', ['force:user:permset:assign', '--permsetname', permissionsets, '--json']);
           } catch (error) {
             EONLogger.log(COLOR_NOTIFY('Assigning Permissionset finished with following message(s):'));
             console.log(error?.stdout);
@@ -78,7 +78,7 @@ export default class Apply extends SfdxCommand {
           title: `Executing Apex: ${devkit.anonymous_apex}`,
           task: async () => {
             try {
-              await execa('sfdx', ['force:apex:execute', '-f ', script]);
+              await execa('sfdx', ['apex:execute', '-f ', script]);
               EONLogger.log(COLOR_TRACE('Script executed'));
             } catch (error) {
               EONLogger.log(COLOR_NOTIFY('Executing Anonymous Apex finished with following message:'));


### PR DESCRIPTION
sfdx force:apex:execute command alias is deprecated and it is replaced by sfdx apex:run
So it is causing this warning:
![image](https://github.com/eon-com/eon-sfdx/assets/17108071/e044b38a-cf75-49b4-9dcd-acb35e347312)
This PR is replacing the command with new one, so the warning is no longer appearing

![image](https://github.com/eon-com/eon-sfdx/assets/17108071/d3ea481c-0ae3-4e35-acdd-46e7552affbd)
